### PR TITLE
Fix for several transaction search fields

### DIFF
--- a/lib/Net/Braintree/CreditCard/CardType.pm
+++ b/lib/Net/Braintree/CreditCard/CardType.pm
@@ -15,7 +15,7 @@ use constant Switch => "Switch";
 use constant Visa => "Visa";
 use constant Unknown => "Unknown";
 
-use constant All => [
+use constant All => (
   AmericanExpress,
   CarteBlanche,
   ChinaUnionPay,
@@ -29,5 +29,6 @@ use constant All => [
   Switch,
   Visa,
   Unknown
-];
+);
+
 1;

--- a/lib/Net/Braintree/Transaction/Source.pm
+++ b/lib/Net/Braintree/Transaction/Source.pm
@@ -5,5 +5,10 @@ use constant Api => "api";
 use constant ControlPanel => "control_panel";
 use constant Recurring => "recurring";
 
-use constant All => [Api, ControlPanel, Recurring];
+use constant All => (
+  Api,
+  ControlPanel,
+  Recurring
+);
+
 1;

--- a/lib/Net/Braintree/Transaction/Type.pm
+++ b/lib/Net/Braintree/Transaction/Type.pm
@@ -4,5 +4,9 @@ use strict;
 use constant Sale => "sale";
 use constant Credit => "credit";
 
-use constant All => [Sale, Credit];
+use constant All => (
+  Sale,
+  Credit,
+);
+
 1;


### PR DESCRIPTION
In a handful of places the "All" constant for search field objects were being set to an arrayref rather than an array. Since these constants are used to validate parameters passed to the search the following error was being given on valid values:

"Invalid Argument(s) for source: api"
