### PR TITLE
Add prerequisite on Switch module which was removed from the Perl core in 5.14

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -20,6 +20,7 @@ requires       'LWP'         => '6.02';
 requires       'LWP::Protocol::https';
 requires       'Module::Install::TestTarget';
 requires       'Moose';
+requires       'Switch';
 requires       'URI::Query';
 requires       'XML::Simple';
 test_requires  'Test::More'  => '0.98';


### PR DESCRIPTION
Please apply this patch so Net::Braintree can be installed on recent Perls.

Regards
               Racke
