### PR TITLE
Prevent Perl warning caused by deprecated use of length(@left_bytes).

### DIFF
--- a/lib/Net/Braintree/Digest.pm
+++ b/lib/Net/Braintree/Digest.pm
@@ -34,12 +34,12 @@ sub secure_compare {
   my @left_bytes = unpack("C*", $left);
   my @right_bytes = unpack("C*", $right);
 
-  if (length(@left_bytes) != length(@right_bytes)) {
+  if (scalar(@left_bytes) != scalar(@right_bytes)) {
     return 0;
   }
 
   my $result = 0;
-  for (my $i = 0; $i < length(@left_bytes); $i++) {
+  for (my $i = 0; $i < scalar(@left_bytes); $i++) {
     $result |= $left_bytes[$i] ^ $right_bytes[$i];
   }
   return $result == 0;


### PR DESCRIPTION
Shows up in tests with Perl 5.18.