### PR TITLE
Allow submit_for_settlement to pass an amount, per API docs.

### DIFF
--- a/lib/Net/Braintree/Transaction.pm
+++ b/lib/Net/Braintree/Transaction.pm
@@ -38,8 +38,10 @@ sub credit {
 }
 
 sub submit_for_settlement {
-  my ($class, $id) = @_;
-  $class->gateway->transaction->submit_for_settlement($id);
+  my ($class, $id, $amount) = @_;
+  my $params = {};
+  $params->{'amount'} = $amount if $amount;
+  $class->gateway->transaction->submit_for_settlement($id, $params);
 }
 
 sub void {

--- a/lib/Net/Braintree/TransactionGateway.pm
+++ b/lib/Net/Braintree/TransactionGateway.pm
@@ -31,8 +31,8 @@ sub retry_subscription_charge {
 }
 
 sub submit_for_settlement {
-  my ($self, $id) = @_;
-  $self->_make_request("/transactions/$id/submit_for_settlement", "put", undef);
+  my ($self, $id, $params) = @_;
+  $self->_make_request("/transactions/$id/submit_for_settlement", "put", {transaction => $params});
 }
 
 sub void {


### PR DESCRIPTION
As documented here: https://www.braintreepayments.com/docs/perl/transactions/submit_for_settlement

...submit_for_settlement can take an amount, with the purpose of settling a change with an amount lower than the original authorization. These changes enable that functionality.