### PR TITLE
Braintree sandbox api does not always return Content_Length header.

### DIFF
--- a/lib/Net/Braintree/HTTP.pm
+++ b/lib/Net/Braintree/HTTP.pm
@@ -47,7 +47,7 @@ sub make_request {
 
   $self->check_response_code($response->code);
 
-  if($response->header('Content-Length') > 1) {
+  if (length($response->content) >= 1) {
     return xml_to_hash($response->content);
   } else {
     return {http_status => $response->code};


### PR DESCRIPTION
We've been getting random periods where Content_length sometimes is defined and sometimes not.  We noticed that the ruby module does not check for Content_Length.  This seems like a good fix - it has been working for us.