### PR TITLE
fix type-o 

### DIFF
--- a/lib/Net/Braintree/ErrorCodes/MerchantAccount/ApplicantDetails/Address.pm
+++ b/lib/Net/Braintree/ErrorCodes/MerchantAccount/ApplicantDetails/Address.pm
@@ -1,4 +1,4 @@
-package Net::Braintree::ErrorCodes::MerchantAccount::AppliantDetails::Address;
+package Net::Braintree::ErrorCodes::MerchantAccount::ApplicantDetails::Address;
 use strict;
 
 use constant LocalityIsRequired      => "82618";


### PR DESCRIPTION
Net::Braintree::ErrorCodes::MerchantAccount::ApplicantDetails::Address had a type-o in the package declaration.  Not sure if it caused any practical issues, but it creates a dependency failure when packaging to RPM w/ rpmbuild. 


