### PR TITLE
Code improvements

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -23,6 +23,7 @@ requires       'LWP::Protocol::https';
 requires       'MIME::Base64';
 requires       'Module::Install::TestTarget';
 requires       'Moose';
+requires       'Moo';
 requires       'Mozilla::CA';
 requires       'URI::Query';
 requires       'XML::Simple';

--- a/lib/Net/Braintree/Address.pm
+++ b/lib/Net/Braintree/Address.pm
@@ -36,5 +36,4 @@ sub full_name {
   return $self->first_name . " " . $self->last_name
 }
 
-__PACKAGE__->meta->make_immutable;
 1;

--- a/lib/Net/Braintree/Address.pm
+++ b/lib/Net/Braintree/Address.pm
@@ -1,5 +1,5 @@
 package Net::Braintree::Address;
-use Moose;
+use Moo;
 extends 'Net::Braintree::ResultObject';
 
 sub BUILD {

--- a/lib/Net/Braintree/Address.pm
+++ b/lib/Net/Braintree/Address.pm
@@ -36,4 +36,5 @@ sub full_name {
   return $self->first_name . " " . $self->last_name
 }
 
+__PACKAGE__->meta->make_immutable;
 1;

--- a/lib/Net/Braintree/AddressGateway.pm
+++ b/lib/Net/Braintree/AddressGateway.pm
@@ -39,5 +39,4 @@ sub _make_request {
 }
 
 
-__PACKAGE__->meta->make_immutable;
 1;

--- a/lib/Net/Braintree/AddressGateway.pm
+++ b/lib/Net/Braintree/AddressGateway.pm
@@ -1,5 +1,5 @@
 package Net::Braintree::AddressGateway;
-use Moose;
+use Moo;
 use Carp qw(confess);
 use Net::Braintree::Validations qw(verify_params address_signature);
 use Net::Braintree::Util qw(validate_id);

--- a/lib/Net/Braintree/AddressGateway.pm
+++ b/lib/Net/Braintree/AddressGateway.pm
@@ -39,4 +39,5 @@ sub _make_request {
 }
 
 
+__PACKAGE__->meta->make_immutable;
 1;

--- a/lib/Net/Braintree/AdvancedSearchFields.pm
+++ b/lib/Net/Braintree/AdvancedSearchFields.pm
@@ -1,7 +1,7 @@
 {
   package Net::Braintree::AdvancedSearchFields;
   use Carp;
-  use Moose;
+  use Moo;
 
   has "metaclass" => (is => 'rw');
 

--- a/lib/Net/Braintree/AdvancedSearchFields.pm
+++ b/lib/Net/Braintree/AdvancedSearchFields.pm
@@ -63,6 +63,5 @@
     });
   }
 
-__PACKAGE__->meta->make_immutable;
   1;
 }

--- a/lib/Net/Braintree/AdvancedSearchFields.pm
+++ b/lib/Net/Braintree/AdvancedSearchFields.pm
@@ -63,5 +63,6 @@
     });
   }
 
+__PACKAGE__->meta->make_immutable;
   1;
 }

--- a/lib/Net/Braintree/AdvancedSearchNodes.pm
+++ b/lib/Net/Braintree/AdvancedSearchNodes.pm
@@ -27,7 +27,6 @@
     return $self->searcher;
   }
 
-__PACKAGE__->meta->make_immutable;
   1;
 }
 
@@ -40,7 +39,6 @@ __PACKAGE__->meta->make_immutable;
     my ($self, $operand) = @_;
     return $self->add_node("is", $operand);
   }
-__PACKAGE__->meta->make_immutable;
   1;
 }
 
@@ -53,7 +51,6 @@ __PACKAGE__->meta->make_immutable;
     my ($self, $operand) = @_;
     return $self->add_node("is_not", $operand);
   }
-__PACKAGE__->meta->make_immutable;
   1;
 }
 
@@ -76,7 +73,6 @@ __PACKAGE__->meta->make_immutable;
     $self->criteria($operand);
     return $self->searcher;
   }
-__PACKAGE__->meta->make_immutable;
   1;
 }
 
@@ -94,7 +90,6 @@ __PACKAGE__->meta->make_immutable;
     my ($self, $operand) = @_;
     return $self->add_node("ends_with", $operand);
   }
-__PACKAGE__->meta->make_immutable;
   1;
 }
 
@@ -107,7 +102,6 @@ __PACKAGE__->meta->make_immutable;
     my ($self, $operand) = @_;
     return $self->add_node("contains", $operand);
   }
-__PACKAGE__->meta->make_immutable;
   1;
 }
 
@@ -134,7 +128,6 @@ __PACKAGE__->meta->make_immutable;
     $self->min($min);
   }
 
-__PACKAGE__->meta->make_immutable;
   1;
 }
 
@@ -185,6 +178,5 @@ __PACKAGE__->meta->make_immutable;
     return $self->searcher;
   }
 
-__PACKAGE__->meta->make_immutable;
   1;
 }

--- a/lib/Net/Braintree/AdvancedSearchNodes.pm
+++ b/lib/Net/Braintree/AdvancedSearchNodes.pm
@@ -1,11 +1,11 @@
 {
   package Net::Braintree::AdvancedSearchNodes;
-  use Moose;
+  use Moo;
 }
 
 {
   package Net::Braintree::SearchNode;
-  use Moose;
+  use Moo;
 
   has 'searcher' => (is => 'rw');
   has 'name' => (is => 'rw');
@@ -33,7 +33,7 @@ __PACKAGE__->meta->make_immutable;
 
 {
   package Net::Braintree::IsNode;
-  use Moose;
+  use Moo;
   extends ("Net::Braintree::SearchNode");
 
   sub is {
@@ -46,7 +46,7 @@ __PACKAGE__->meta->make_immutable;
 
 {
   package Net::Braintree::EqualityNode;
-  use Moose;
+  use Moo;
   extends ("Net::Braintree::IsNode");
 
   sub is_not {
@@ -59,7 +59,7 @@ __PACKAGE__->meta->make_immutable;
 
 {
   package Net::Braintree::KeyValueNode;
-  use Moose;
+  use Moo;
   extends ("Net::Braintree::SearchNode");
 
   sub default_criteria {
@@ -82,7 +82,7 @@ __PACKAGE__->meta->make_immutable;
 
 {
   package Net::Braintree::PartialMatchNode;
-  use Moose;
+  use Moo;
   extends ("Net::Braintree::EqualityNode");
 
   sub starts_with {
@@ -100,7 +100,7 @@ __PACKAGE__->meta->make_immutable;
 
 {
   package Net::Braintree::TextNode;
-  use Moose;
+  use Moo;
   extends ("Net::Braintree::PartialMatchNode");
 
   sub contains {
@@ -113,7 +113,7 @@ __PACKAGE__->meta->make_immutable;
 
 {
   package Net::Braintree::RangeNode;
-  use Moose;
+  use Moo;
   extends ("Net::Braintree::EqualityNode");
 
   use overload ( '>=' => 'min', '<=' => 'max');
@@ -141,7 +141,7 @@ __PACKAGE__->meta->make_immutable;
 {
   package Net::Braintree::MultipleValuesNode;
   use Carp;
-  use Moose;
+  use Moo;
   use Net::Braintree::Util;
   extends ("Net::Braintree::SearchNode");
 

--- a/lib/Net/Braintree/AdvancedSearchNodes.pm
+++ b/lib/Net/Braintree/AdvancedSearchNodes.pm
@@ -27,6 +27,7 @@
     return $self->searcher;
   }
 
+__PACKAGE__->meta->make_immutable;
   1;
 }
 
@@ -39,6 +40,7 @@
     my ($self, $operand) = @_;
     return $self->add_node("is", $operand);
   }
+__PACKAGE__->meta->make_immutable;
   1;
 }
 
@@ -51,6 +53,7 @@
     my ($self, $operand) = @_;
     return $self->add_node("is_not", $operand);
   }
+__PACKAGE__->meta->make_immutable;
   1;
 }
 
@@ -73,6 +76,7 @@
     $self->criteria($operand);
     return $self->searcher;
   }
+__PACKAGE__->meta->make_immutable;
   1;
 }
 
@@ -90,6 +94,7 @@
     my ($self, $operand) = @_;
     return $self->add_node("ends_with", $operand);
   }
+__PACKAGE__->meta->make_immutable;
   1;
 }
 
@@ -102,6 +107,7 @@
     my ($self, $operand) = @_;
     return $self->add_node("contains", $operand);
   }
+__PACKAGE__->meta->make_immutable;
   1;
 }
 
@@ -128,6 +134,7 @@
     $self->min($min);
   }
 
+__PACKAGE__->meta->make_immutable;
   1;
 }
 
@@ -178,5 +185,6 @@
     return $self->searcher;
   }
 
+__PACKAGE__->meta->make_immutable;
   1;
 }

--- a/lib/Net/Braintree/ApplePayCard.pm
+++ b/lib/Net/Braintree/ApplePayCard.pm
@@ -18,5 +18,4 @@ sub is_default {
   return shift->default;
 }
 
-__PACKAGE__->meta->make_immutable;
 1;

--- a/lib/Net/Braintree/ApplePayCard.pm
+++ b/lib/Net/Braintree/ApplePayCard.pm
@@ -20,4 +20,5 @@ sub is_default {
   return shift->default;
 }
 
+__PACKAGE__->meta->make_immutable;
 1;

--- a/lib/Net/Braintree/ApplePayCard.pm
+++ b/lib/Net/Braintree/ApplePayCard.pm
@@ -4,8 +4,6 @@ use Net::Braintree::ApplePayCard::CardType;
 use Moose;
 extends 'Net::Braintree::PaymentMethod';
 
-my $meta = __PACKAGE__->meta;
-
 sub BUILD {
   my ($self, $attributes) = @_;
   $self->set_attributes_from_hash($self, $attributes);

--- a/lib/Net/Braintree/ApplePayCard.pm
+++ b/lib/Net/Braintree/ApplePayCard.pm
@@ -1,7 +1,7 @@
 package Net::Braintree::ApplePayCard;
 use Net::Braintree::ApplePayCard::CardType;
 
-use Moose;
+use Moo;
 extends 'Net::Braintree::PaymentMethod';
 
 sub BUILD {

--- a/lib/Net/Braintree/ClientTokenGateway.pm
+++ b/lib/Net/Braintree/ClientTokenGateway.pm
@@ -33,5 +33,4 @@ sub _conditionally_verify_params {
   };
 }
 
-__PACKAGE__->meta->make_immutable;
 1;

--- a/lib/Net/Braintree/ClientTokenGateway.pm
+++ b/lib/Net/Braintree/ClientTokenGateway.pm
@@ -1,5 +1,5 @@
 package Net::Braintree::ClientTokenGateway;
-use Moose;
+use Moo;
 use Carp qw(confess);
 use Net::Braintree::Validations qw(verify_params client_token_signature_with_customer_id client_token_signature_without_customer_id);
 use Net::Braintree::Result;

--- a/lib/Net/Braintree/ClientTokenGateway.pm
+++ b/lib/Net/Braintree/ClientTokenGateway.pm
@@ -33,4 +33,5 @@ sub _conditionally_verify_params {
   };
 }
 
+__PACKAGE__->meta->make_immutable;
 1;

--- a/lib/Net/Braintree/Configuration.pm
+++ b/lib/Net/Braintree/Configuration.pm
@@ -80,5 +80,4 @@ sub api_version {
   return "4";
 }
 
-__PACKAGE__->meta->make_immutable;
 1;

--- a/lib/Net/Braintree/Configuration.pm
+++ b/lib/Net/Braintree/Configuration.pm
@@ -1,7 +1,7 @@
 package Net::Braintree::Configuration;
 
 use Net::Braintree::Gateway;
-use Moose;
+use Moo;
 
 has merchant_id => (is => 'rw');
 has partner_id => (is => 'rw');

--- a/lib/Net/Braintree/Configuration.pm
+++ b/lib/Net/Braintree/Configuration.pm
@@ -80,4 +80,5 @@ sub api_version {
   return "4";
 }
 
+__PACKAGE__->meta->make_immutable;
 1;

--- a/lib/Net/Braintree/CreditCard.pm
+++ b/lib/Net/Braintree/CreditCard.pm
@@ -13,10 +13,9 @@ use Net::Braintree::CreditCard::IssuingBank;
 use Moose;
 extends 'Net::Braintree::PaymentMethod';
 
-my $meta = __PACKAGE__->meta;
-
 sub BUILD {
   my ($self, $attributes) = @_;
+  my $meta = __PACKAGE__->meta;
   $meta->add_attribute('billing_address', is => 'rw');
   $self->billing_address(Net::Braintree::Address->new($attributes->{billing_address})) if ref($attributes->{billing_address}) eq 'HASH';
   delete($attributes->{billing_address});

--- a/lib/Net/Braintree/CreditCardGateway.pm
+++ b/lib/Net/Braintree/CreditCardGateway.pm
@@ -49,5 +49,4 @@ sub _make_request {
   return $result;
 }
 
-__PACKAGE__->meta->make_immutable;
 1;

--- a/lib/Net/Braintree/CreditCardGateway.pm
+++ b/lib/Net/Braintree/CreditCardGateway.pm
@@ -1,5 +1,5 @@
 package Net::Braintree::CreditCardGateway;
-use Moose;
+use Moo;
 use Carp qw(confess);
 use Net::Braintree::Validations qw(verify_params credit_card_signature);
 use Net::Braintree::Util qw(validate_id);

--- a/lib/Net/Braintree/CreditCardGateway.pm
+++ b/lib/Net/Braintree/CreditCardGateway.pm
@@ -49,4 +49,5 @@ sub _make_request {
   return $result;
 }
 
+__PACKAGE__->meta->make_immutable;
 1;

--- a/lib/Net/Braintree/CreditCardVerification.pm
+++ b/lib/Net/Braintree/CreditCardVerification.pm
@@ -38,5 +38,4 @@ sub gateway {
 }
 
 
-__PACKAGE__->meta->make_immutable;
 1;

--- a/lib/Net/Braintree/CreditCardVerification.pm
+++ b/lib/Net/Braintree/CreditCardVerification.pm
@@ -38,4 +38,5 @@ sub gateway {
 }
 
 
+__PACKAGE__->meta->make_immutable;
 1;

--- a/lib/Net/Braintree/CreditCardVerification.pm
+++ b/lib/Net/Braintree/CreditCardVerification.pm
@@ -2,7 +2,7 @@ package Net::Braintree::CreditCardVerification;
 use Net::Braintree::CreditCard;
 use Net::Braintree::CreditCard::CardType;
 
-use Moose;
+use Moo;
 
 has 'avs_error_response_code' => (is => 'ro');
 has 'avs_postal_code_response_code' => (is => 'ro');

--- a/lib/Net/Braintree/CreditCardVerificationGateway.pm
+++ b/lib/Net/Braintree/CreditCardVerificationGateway.pm
@@ -40,5 +40,4 @@ sub fetch_verifications {
   return to_instance_array($attrs, "Net::Braintree::CreditCardVerification");
 }
 
-__PACKAGE__->meta->make_immutable;
 1;

--- a/lib/Net/Braintree/CreditCardVerificationGateway.pm
+++ b/lib/Net/Braintree/CreditCardVerificationGateway.pm
@@ -2,6 +2,7 @@ package Net::Braintree::CreditCardVerificationGateway;
 use Moose;
 use Net::Braintree::CreditCardVerificationSearch;
 use Net::Braintree::Util;
+use Carp qw(confess);
 
 has 'gateway' => (is => 'ro');
 

--- a/lib/Net/Braintree/CreditCardVerificationGateway.pm
+++ b/lib/Net/Braintree/CreditCardVerificationGateway.pm
@@ -1,5 +1,5 @@
 package Net::Braintree::CreditCardVerificationGateway;
-use Moose;
+use Moo;
 use Net::Braintree::CreditCardVerificationSearch;
 use Net::Braintree::Util;
 use Carp qw(confess);

--- a/lib/Net/Braintree/CreditCardVerificationGateway.pm
+++ b/lib/Net/Braintree/CreditCardVerificationGateway.pm
@@ -39,4 +39,5 @@ sub fetch_verifications {
   return to_instance_array($attrs, "Net::Braintree::CreditCardVerification");
 }
 
+__PACKAGE__->meta->make_immutable;
 1;

--- a/lib/Net/Braintree/CreditCardVerificationSearch.pm
+++ b/lib/Net/Braintree/CreditCardVerificationSearch.pm
@@ -19,4 +19,5 @@ sub to_hash {
   Net::Braintree::AdvancedSearch->search_to_hash(shift);
 }
 
+__PACKAGE__->meta->make_immutable;
 1;

--- a/lib/Net/Braintree/CreditCardVerificationSearch.pm
+++ b/lib/Net/Braintree/CreditCardVerificationSearch.pm
@@ -19,5 +19,4 @@ sub to_hash {
   Net::Braintree::AdvancedSearch->search_to_hash(shift);
 }
 
-__PACKAGE__->meta->make_immutable;
 1;

--- a/lib/Net/Braintree/CreditCardVerificationSearch.pm
+++ b/lib/Net/Braintree/CreditCardVerificationSearch.pm
@@ -1,5 +1,5 @@
 package Net::Braintree::CreditCardVerificationSearch;
-use Moose;
+use Moo;
 use Net::Braintree::CreditCard::CardType;
 use Net::Braintree::AdvancedSearch qw(search_to_hash);
 my $meta = __PACKAGE__->meta();

--- a/lib/Net/Braintree/Customer.pm
+++ b/lib/Net/Braintree/Customer.pm
@@ -1,5 +1,5 @@
 package Net::Braintree::Customer;
-use Moose;
+use Moo;
 extends 'Net::Braintree::ResultObject';
 
 

--- a/lib/Net/Braintree/Customer.pm
+++ b/lib/Net/Braintree/Customer.pm
@@ -67,5 +67,4 @@ sub gateway {
   return Net::Braintree->configuration->gateway;
 }
 
-__PACKAGE__->meta->make_immutable;
 1;

--- a/lib/Net/Braintree/Customer.pm
+++ b/lib/Net/Braintree/Customer.pm
@@ -68,4 +68,5 @@ sub gateway {
   return Net::Braintree->configuration->gateway;
 }
 
+__PACKAGE__->meta->make_immutable;
 1;

--- a/lib/Net/Braintree/Customer.pm
+++ b/lib/Net/Braintree/Customer.pm
@@ -2,7 +2,6 @@ package Net::Braintree::Customer;
 use Moose;
 extends 'Net::Braintree::ResultObject';
 
-my $meta = __PACKAGE__->meta;
 
 sub BUILD {
   my ($self, $attributes) = @_;

--- a/lib/Net/Braintree/CustomerGateway.pm
+++ b/lib/Net/Braintree/CustomerGateway.pm
@@ -67,5 +67,6 @@ sub fetch_customers {
 }
 
 
+__PACKAGE__->meta->make_immutable;
 1;
 

--- a/lib/Net/Braintree/CustomerGateway.pm
+++ b/lib/Net/Braintree/CustomerGateway.pm
@@ -1,5 +1,5 @@
 package Net::Braintree::CustomerGateway;
-use Moose;
+use Moo;
 use Carp qw(confess);
 use Net::Braintree::Validations qw(verify_params customer_signature);
 use Net::Braintree::Util qw(validate_id);

--- a/lib/Net/Braintree/CustomerGateway.pm
+++ b/lib/Net/Braintree/CustomerGateway.pm
@@ -67,6 +67,5 @@ sub fetch_customers {
 }
 
 
-__PACKAGE__->meta->make_immutable;
 1;
 

--- a/lib/Net/Braintree/CustomerSearch.pm
+++ b/lib/Net/Braintree/CustomerSearch.pm
@@ -34,5 +34,6 @@ sub to_hash {
   Net::Braintree::AdvancedSearch->search_to_hash(shift);
 }
 
+__PACKAGE__->meta->make_immutable;
 1;
 

--- a/lib/Net/Braintree/CustomerSearch.pm
+++ b/lib/Net/Braintree/CustomerSearch.pm
@@ -1,9 +1,8 @@
 package Net::Braintree::CustomerSearch;
 use Moose;
 use Net::Braintree::AdvancedSearch qw(search_to_hash);
-my $meta = __PACKAGE__->meta();
 
-my $field = Net::Braintree::AdvancedSearchFields->new(metaclass => $meta);
+my $field = Net::Braintree::AdvancedSearchFields->new(metaclass => __PACKAGE__->meta);
 $field->text("address_country_name");
 $field->text("address_extended_address");
 $field->text("address_first_name");

--- a/lib/Net/Braintree/CustomerSearch.pm
+++ b/lib/Net/Braintree/CustomerSearch.pm
@@ -1,5 +1,5 @@
 package Net::Braintree::CustomerSearch;
-use Moose;
+use Moo;
 use Net::Braintree::AdvancedSearch qw(search_to_hash);
 
 my $field = Net::Braintree::AdvancedSearchFields->new(metaclass => __PACKAGE__->meta);

--- a/lib/Net/Braintree/CustomerSearch.pm
+++ b/lib/Net/Braintree/CustomerSearch.pm
@@ -33,6 +33,5 @@ sub to_hash {
   Net::Braintree::AdvancedSearch->search_to_hash(shift);
 }
 
-__PACKAGE__->meta->make_immutable;
 1;
 

--- a/lib/Net/Braintree/DisbursementDetails.pm
+++ b/lib/Net/Braintree/DisbursementDetails.pm
@@ -19,5 +19,4 @@ sub is_valid {
   }
 };
 
-__PACKAGE__->meta->make_immutable;
 1;

--- a/lib/Net/Braintree/DisbursementDetails.pm
+++ b/lib/Net/Braintree/DisbursementDetails.pm
@@ -19,4 +19,5 @@ sub is_valid {
   }
 };
 
+__PACKAGE__->meta->make_immutable;
 1;

--- a/lib/Net/Braintree/DisbursementDetails.pm
+++ b/lib/Net/Braintree/DisbursementDetails.pm
@@ -1,6 +1,6 @@
 package Net::Braintree::DisbursementDetails;
 
-use Moose;
+use Moo;
 extends 'Net::Braintree::ResultObject';
 
 my $meta = __PACKAGE__->meta;

--- a/lib/Net/Braintree/Dispute.pm
+++ b/lib/Net/Braintree/Dispute.pm
@@ -6,11 +6,9 @@ use Net::Braintree::Dispute::Reason;
 use Moose;
 extends 'Net::Braintree::ResultObject';
 
-my $meta = __PACKAGE__->meta;
-
 sub BUILD {
   my ($self, $attributes) = @_;
-
+  my $meta = __PACKAGE__->meta;
   $meta->add_attribute('transaction_details', is => 'rw');
   $self->transaction_details(Net::Braintree::Dispute::TransactionDetails->new($attributes->{transaction})) if ref($attributes->{transaction}) eq 'HASH';
   delete($attributes->{transaction});

--- a/lib/Net/Braintree/Dispute/TransactionDetails.pm
+++ b/lib/Net/Braintree/Dispute/TransactionDetails.pm
@@ -10,4 +10,5 @@ sub BUILD {
   $self->set_attributes_from_hash($self, $attributes);
 }
 
+__PACKAGE__->meta->make_immutable;
 1;

--- a/lib/Net/Braintree/Dispute/TransactionDetails.pm
+++ b/lib/Net/Braintree/Dispute/TransactionDetails.pm
@@ -3,7 +3,6 @@ package Net::Braintree::Dispute::TransactionDetails;
 use Moose;
 extends 'Net::Braintree::ResultObject';
 
-my $meta = __PACKAGE__->meta;
 
 sub BUILD {
   my ($self, $attributes) = @_;

--- a/lib/Net/Braintree/Dispute/TransactionDetails.pm
+++ b/lib/Net/Braintree/Dispute/TransactionDetails.pm
@@ -1,6 +1,6 @@
 package Net::Braintree::Dispute::TransactionDetails;
 
-use Moose;
+use Moo;
 extends 'Net::Braintree::ResultObject';
 
 

--- a/lib/Net/Braintree/Dispute/TransactionDetails.pm
+++ b/lib/Net/Braintree/Dispute/TransactionDetails.pm
@@ -9,5 +9,4 @@ sub BUILD {
   $self->set_attributes_from_hash($self, $attributes);
 }
 
-__PACKAGE__->meta->make_immutable;
 1;

--- a/lib/Net/Braintree/Gateway.pm
+++ b/lib/Net/Braintree/Gateway.pm
@@ -93,4 +93,5 @@ sub http {
   Net::Braintree::HTTP->new(config => shift->config);
 }
 
+__PACKAGE__->meta->make_immutable;
 1;

--- a/lib/Net/Braintree/Gateway.pm
+++ b/lib/Net/Braintree/Gateway.pm
@@ -15,7 +15,7 @@ use Net::Braintree::TransparentRedirectGateway;
 use Net::Braintree::WebhookNotificationGateway;
 use Net::Braintree::WebhookTestingGateway;
 
-use Moose;
+use Moo;
 
 has 'config' => (is => 'ro');
 

--- a/lib/Net/Braintree/Gateway.pm
+++ b/lib/Net/Braintree/Gateway.pm
@@ -93,5 +93,4 @@ sub http {
   Net::Braintree::HTTP->new(config => shift->config);
 }
 
-__PACKAGE__->meta->make_immutable;
 1;

--- a/lib/Net/Braintree/HTTP.pm
+++ b/lib/Net/Braintree/HTTP.pm
@@ -63,4 +63,5 @@ sub check_response_code {
   confess "DownForMaintenance"  if $code eq '503';
 }
 
+__PACKAGE__->meta->make_immutable;
 1;

--- a/lib/Net/Braintree/HTTP.pm
+++ b/lib/Net/Braintree/HTTP.pm
@@ -3,7 +3,7 @@ package Net::Braintree::HTTP;
 use HTTP::Request;
 use LWP::UserAgent;
 use Net::Braintree::Xml;
-use Moose;
+use Moo;
 use Carp qw(confess);
 
 has 'config' => (is => 'ro', default => sub { Net::Braintree->configuration });

--- a/lib/Net/Braintree/HTTP.pm
+++ b/lib/Net/Braintree/HTTP.pm
@@ -63,5 +63,4 @@ sub check_response_code {
   confess "DownForMaintenance"  if $code eq '503';
 }
 
-__PACKAGE__->meta->make_immutable;
 1;

--- a/lib/Net/Braintree/MerchantAccount.pm
+++ b/lib/Net/Braintree/MerchantAccount.pm
@@ -6,7 +6,6 @@ use Net::Braintree::MerchantAccount::FundingDetails;
 
 use Moose;
 extends "Net::Braintree::ResultObject";
-my $meta = __PACKAGE__->meta;
 
 {
   package Net::Braintree::MerchantAccount::Status;
@@ -26,6 +25,7 @@ my $meta = __PACKAGE__->meta;
 
 sub BUILD {
   my ($self, $attributes) = @_;
+  my $meta = __PACKAGE__->meta;
   $meta->add_attribute('master_merchant_account', is => 'rw');
   $self->master_merchant_account(Net::Braintree::MerchantAccount->new($attributes->{master_merchant_account})) if ref($attributes->{master_merchant_account}) eq 'HASH';
   delete($attributes->{master_merchant_account});

--- a/lib/Net/Braintree/MerchantAccount/AddressDetails.pm
+++ b/lib/Net/Braintree/MerchantAccount/AddressDetails.pm
@@ -9,4 +9,5 @@ sub BUILD {
   $self->set_attributes_from_hash($self, $attributes);
 }
 
+__PACKAGE__->meta->make_immutable;
 1;

--- a/lib/Net/Braintree/MerchantAccount/AddressDetails.pm
+++ b/lib/Net/Braintree/MerchantAccount/AddressDetails.pm
@@ -8,5 +8,4 @@ sub BUILD {
   $self->set_attributes_from_hash($self, $attributes);
 }
 
-__PACKAGE__->meta->make_immutable;
 1;

--- a/lib/Net/Braintree/MerchantAccount/AddressDetails.pm
+++ b/lib/Net/Braintree/MerchantAccount/AddressDetails.pm
@@ -1,6 +1,6 @@
 package Net::Braintree::MerchantAccount::AddressDetails;
 
-use Moose;
+use Moo;
 extends "Net::Braintree::ResultObject";
 
 sub BUILD {

--- a/lib/Net/Braintree/MerchantAccount/AddressDetails.pm
+++ b/lib/Net/Braintree/MerchantAccount/AddressDetails.pm
@@ -2,7 +2,6 @@ package Net::Braintree::MerchantAccount::AddressDetails;
 
 use Moose;
 extends "Net::Braintree::ResultObject";
-my $meta = __PACKAGE__->meta;
 
 sub BUILD {
   my ($self, $attributes) = @_;

--- a/lib/Net/Braintree/MerchantAccount/BusinessDetails.pm
+++ b/lib/Net/Braintree/MerchantAccount/BusinessDetails.pm
@@ -3,10 +3,11 @@ use Net::Braintree::MerchantAccount::AddressDetails;
 
 use Moose;
 extends "Net::Braintree::ResultObject";
-my $meta = __PACKAGE__->meta;
+
 
 sub BUILD {
   my ($self, $attributes) = @_;
+  my $meta = __PACKAGE__->meta;
 
   $meta->add_attribute('address_details', is => 'rw');
   $self->address_details(Net::Braintree::MerchantAccount::AddressDetails->new($attributes->{address})) if ref($attributes->{address}) eq 'HASH';

--- a/lib/Net/Braintree/MerchantAccount/FundingDetails.pm
+++ b/lib/Net/Braintree/MerchantAccount/FundingDetails.pm
@@ -9,4 +9,5 @@ sub BUILD {
   $self->set_attributes_from_hash($self, $attributes);
 }
 
+__PACKAGE__->meta->make_immutable;
 1;

--- a/lib/Net/Braintree/MerchantAccount/FundingDetails.pm
+++ b/lib/Net/Braintree/MerchantAccount/FundingDetails.pm
@@ -8,5 +8,4 @@ sub BUILD {
   $self->set_attributes_from_hash($self, $attributes);
 }
 
-__PACKAGE__->meta->make_immutable;
 1;

--- a/lib/Net/Braintree/MerchantAccount/FundingDetails.pm
+++ b/lib/Net/Braintree/MerchantAccount/FundingDetails.pm
@@ -1,6 +1,6 @@
 package Net::Braintree::MerchantAccount::FundingDetails;
 
-use Moose;
+use Moo;
 extends "Net::Braintree::ResultObject";
 
 sub BUILD {

--- a/lib/Net/Braintree/MerchantAccount/FundingDetails.pm
+++ b/lib/Net/Braintree/MerchantAccount/FundingDetails.pm
@@ -2,7 +2,6 @@ package Net::Braintree::MerchantAccount::FundingDetails;
 
 use Moose;
 extends "Net::Braintree::ResultObject";
-my $meta = __PACKAGE__->meta;
 
 sub BUILD {
   my ($self, $attributes) = @_;

--- a/lib/Net/Braintree/MerchantAccount/IndividualDetails.pm
+++ b/lib/Net/Braintree/MerchantAccount/IndividualDetails.pm
@@ -3,11 +3,11 @@ use Net::Braintree::MerchantAccount::AddressDetails;
 
 use Moose;
 extends "Net::Braintree::ResultObject";
-my $meta = __PACKAGE__->meta;
+
 
 sub BUILD {
   my ($self, $attributes) = @_;
-
+  my $meta = __PACKAGE__->meta;
   $meta->add_attribute('address_details', is => 'rw');
   $self->address_details(Net::Braintree::MerchantAccount::AddressDetails->new($attributes->{address})) if ref($attributes->{address}) eq 'HASH';
   delete($attributes->{address});

--- a/lib/Net/Braintree/MerchantAccountGateway.pm
+++ b/lib/Net/Braintree/MerchantAccountGateway.pm
@@ -149,5 +149,4 @@ sub _update_signature{
   };
 }
 
-__PACKAGE__->meta->make_immutable;
 1;

--- a/lib/Net/Braintree/MerchantAccountGateway.pm
+++ b/lib/Net/Braintree/MerchantAccountGateway.pm
@@ -149,4 +149,5 @@ sub _update_signature{
   };
 }
 
+__PACKAGE__->meta->make_immutable;
 1;

--- a/lib/Net/Braintree/MerchantAccountGateway.pm
+++ b/lib/Net/Braintree/MerchantAccountGateway.pm
@@ -1,5 +1,5 @@
 package Net::Braintree::MerchantAccountGateway;
-use Moose;
+use Moo;
 use Carp qw(confess);
 use Net::Braintree::Validations qw(verify_params);
 use Net::Braintree::Util qw(validate_id);

--- a/lib/Net/Braintree/PartnerMerchant.pm
+++ b/lib/Net/Braintree/PartnerMerchant.pm
@@ -1,5 +1,5 @@
 package Net::Braintree::PartnerMerchant;
-use Moose;
+use Moo;
 extends 'Net::Braintree::ResultObject';
 
 sub BUILD {

--- a/lib/Net/Braintree/PartnerMerchant.pm
+++ b/lib/Net/Braintree/PartnerMerchant.pm
@@ -7,4 +7,5 @@ sub BUILD {
   $self->set_attributes_from_hash($self, $attributes);
 }
 
+__PACKAGE__->meta->make_immutable;
 1;

--- a/lib/Net/Braintree/PartnerMerchant.pm
+++ b/lib/Net/Braintree/PartnerMerchant.pm
@@ -7,5 +7,4 @@ sub BUILD {
   $self->set_attributes_from_hash($self, $attributes);
 }
 
-__PACKAGE__->meta->make_immutable;
 1;

--- a/lib/Net/Braintree/PayPalAccount.pm
+++ b/lib/Net/Braintree/PayPalAccount.pm
@@ -2,8 +2,6 @@ package Net::Braintree::PayPalAccount;
 use Moose;
 extends 'Net::Braintree::PaymentMethod';
 
-my $meta = __PACKAGE__->meta;
-
 sub BUILD {
   my ($self, $attributes) = @_;
   $self->set_attributes_from_hash($self, $attributes);

--- a/lib/Net/Braintree/PayPalAccount.pm
+++ b/lib/Net/Braintree/PayPalAccount.pm
@@ -1,5 +1,5 @@
 package Net::Braintree::PayPalAccount;
-use Moose;
+use Moo;
 extends 'Net::Braintree::PaymentMethod';
 
 sub BUILD {

--- a/lib/Net/Braintree/PayPalAccount.pm
+++ b/lib/Net/Braintree/PayPalAccount.pm
@@ -23,5 +23,4 @@ sub gateway {
   Net::Braintree->configuration->gateway;
 }
 
-__PACKAGE__->meta->make_immutable;
 1;

--- a/lib/Net/Braintree/PayPalAccount.pm
+++ b/lib/Net/Braintree/PayPalAccount.pm
@@ -25,4 +25,5 @@ sub gateway {
   Net::Braintree->configuration->gateway;
 }
 
+__PACKAGE__->meta->make_immutable;
 1;

--- a/lib/Net/Braintree/PayPalAccountGateway.pm
+++ b/lib/Net/Braintree/PayPalAccountGateway.pm
@@ -1,5 +1,5 @@
 package Net::Braintree::PayPalAccountGateway;
-use Moose;
+use Moo;
 use Carp qw(confess);
 
 has 'gateway' => (is => 'ro');

--- a/lib/Net/Braintree/PayPalAccountGateway.pm
+++ b/lib/Net/Braintree/PayPalAccountGateway.pm
@@ -26,4 +26,5 @@ sub _make_request {
   return $result;
 }
 
+__PACKAGE__->meta->make_immutable;
 1;

--- a/lib/Net/Braintree/PayPalAccountGateway.pm
+++ b/lib/Net/Braintree/PayPalAccountGateway.pm
@@ -26,5 +26,4 @@ sub _make_request {
   return $result;
 }
 
-__PACKAGE__->meta->make_immutable;
 1;

--- a/lib/Net/Braintree/PayPalDetails.pm
+++ b/lib/Net/Braintree/PayPalDetails.pm
@@ -1,6 +1,6 @@
 package Net::Braintree::PayPalDetails;
 
-use Moose;
+use Moo;
 extends 'Net::Braintree::ResultObject';
 
 sub BUILD {

--- a/lib/Net/Braintree/PayPalDetails.pm
+++ b/lib/Net/Braintree/PayPalDetails.pm
@@ -8,4 +8,5 @@ sub BUILD {
   $self->set_attributes_from_hash($self, $attributes); 
 }
 
+__PACKAGE__->meta->make_immutable;
 1;

--- a/lib/Net/Braintree/PayPalDetails.pm
+++ b/lib/Net/Braintree/PayPalDetails.pm
@@ -8,5 +8,4 @@ sub BUILD {
   $self->set_attributes_from_hash($self, $attributes); 
 }
 
-__PACKAGE__->meta->make_immutable;
 1;

--- a/lib/Net/Braintree/PaymentMethod.pm
+++ b/lib/Net/Braintree/PaymentMethod.pm
@@ -1,5 +1,5 @@
 package Net::Braintree::PaymentMethod;
-use Moose;
+use Moo;
 extends 'Net::Braintree::ResultObject';
 
 has token => ( is => 'rw' );

--- a/lib/Net/Braintree/PaymentMethod.pm
+++ b/lib/Net/Braintree/PaymentMethod.pm
@@ -28,4 +28,5 @@ sub gateway {
   return Net::Braintree->configuration->gateway;
 }
 
+__PACKAGE__->meta->make_immutable;
 1;

--- a/lib/Net/Braintree/PaymentMethod.pm
+++ b/lib/Net/Braintree/PaymentMethod.pm
@@ -28,5 +28,4 @@ sub gateway {
   return Net::Braintree->configuration->gateway;
 }
 
-__PACKAGE__->meta->make_immutable;
 1;

--- a/lib/Net/Braintree/PaymentMethodGateway.pm
+++ b/lib/Net/Braintree/PaymentMethodGateway.pm
@@ -36,5 +36,4 @@ sub _make_request {
   return Net::Braintree::Result->new(response => $response);
 }
 
-__PACKAGE__->meta->make_immutable;
 1;

--- a/lib/Net/Braintree/PaymentMethodGateway.pm
+++ b/lib/Net/Braintree/PaymentMethodGateway.pm
@@ -36,4 +36,5 @@ sub _make_request {
   return Net::Braintree::Result->new(response => $response);
 }
 
+__PACKAGE__->meta->make_immutable;
 1;

--- a/lib/Net/Braintree/PaymentMethodGateway.pm
+++ b/lib/Net/Braintree/PaymentMethodGateway.pm
@@ -1,5 +1,5 @@
 package Net::Braintree::PaymentMethodGateway;
-use Moose;
+use Moo;
 use Carp qw(confess);
 
 has 'gateway' => (is => 'ro');

--- a/lib/Net/Braintree/ResourceCollection.pm
+++ b/lib/Net/Braintree/ResourceCollection.pm
@@ -62,4 +62,5 @@ sub execute_block_for_page {
   }
 }
 
+__PACKAGE__->meta->make_immutable;
 1;

--- a/lib/Net/Braintree/ResourceCollection.pm
+++ b/lib/Net/Braintree/ResourceCollection.pm
@@ -62,5 +62,4 @@ sub execute_block_for_page {
   }
 }
 
-__PACKAGE__->meta->make_immutable;
 1;

--- a/lib/Net/Braintree/ResourceCollection.pm
+++ b/lib/Net/Braintree/ResourceCollection.pm
@@ -1,5 +1,5 @@
 package Net::Braintree::ResourceCollection;
-use Moose;
+use Moo;
 extends "Net::Braintree::ResultObject";
 
 has 'response' => (is => 'rw');

--- a/lib/Net/Braintree/Result.pm
+++ b/lib/Net/Braintree/Result.pm
@@ -92,5 +92,4 @@ sub credit_card_verification {
   return Net::Braintree::CreditCardVerification->new($self->api_error_response->{verification});
 }
 
-__PACKAGE__->meta->make_immutable;
 1;

--- a/lib/Net/Braintree/Result.pm
+++ b/lib/Net/Braintree/Result.pm
@@ -92,4 +92,5 @@ sub credit_card_verification {
   return Net::Braintree::CreditCardVerification->new($self->api_error_response->{verification});
 }
 
+__PACKAGE__->meta->make_immutable;
 1;

--- a/lib/Net/Braintree/Result.pm
+++ b/lib/Net/Braintree/Result.pm
@@ -1,5 +1,5 @@
 package Net::Braintree::Result;
-use Moose;
+use Moo;
 use Hash::Inflator;
 use Net::Braintree::Util;
 use Net::Braintree::ValidationErrorCollection;

--- a/lib/Net/Braintree/SettlementBatchSummary.pm
+++ b/lib/Net/Braintree/SettlementBatchSummary.pm
@@ -16,5 +16,4 @@ sub gateway {
   return Net::Braintree->configuration->gateway;
 }
 
-__PACKAGE__->meta->make_immutable;
 1;

--- a/lib/Net/Braintree/SettlementBatchSummary.pm
+++ b/lib/Net/Braintree/SettlementBatchSummary.pm
@@ -1,5 +1,5 @@
 package Net::Braintree::SettlementBatchSummary;
-use Moose;
+use Moo;
 extends 'Net::Braintree::ResultObject';
 
 sub BUILD {

--- a/lib/Net/Braintree/SettlementBatchSummary.pm
+++ b/lib/Net/Braintree/SettlementBatchSummary.pm
@@ -16,4 +16,5 @@ sub gateway {
   return Net::Braintree->configuration->gateway;
 }
 
+__PACKAGE__->meta->make_immutable;
 1;

--- a/lib/Net/Braintree/SettlementBatchSummaryGateway.pm
+++ b/lib/Net/Braintree/SettlementBatchSummaryGateway.pm
@@ -21,5 +21,4 @@ sub _make_request {
   return $result;
 }
 
-__PACKAGE__->meta->make_immutable;
 1;

--- a/lib/Net/Braintree/SettlementBatchSummaryGateway.pm
+++ b/lib/Net/Braintree/SettlementBatchSummaryGateway.pm
@@ -1,5 +1,5 @@
 package Net::Braintree::SettlementBatchSummaryGateway;
-use Moose;
+use Moo;
 use Carp qw(confess);
 
 has 'gateway' => (is => 'ro');

--- a/lib/Net/Braintree/SettlementBatchSummaryGateway.pm
+++ b/lib/Net/Braintree/SettlementBatchSummaryGateway.pm
@@ -21,4 +21,5 @@ sub _make_request {
   return $result;
 }
 
+__PACKAGE__->meta->make_immutable;
 1;

--- a/lib/Net/Braintree/Subscription.pm
+++ b/lib/Net/Braintree/Subscription.pm
@@ -52,5 +52,4 @@ sub gateway {
   return Net::Braintree->configuration->gateway;
 }
 
-__PACKAGE__->meta->make_immutable;
 1;

--- a/lib/Net/Braintree/Subscription.pm
+++ b/lib/Net/Braintree/Subscription.pm
@@ -5,7 +5,6 @@ use Net::Braintree::Subscription::Status;
 use Moose;
 extends 'Net::Braintree::ResultObject';
 
-my $meta = __PACKAGE__->meta;
 
 sub BUILD {
   my ($self, $attributes) = @_;

--- a/lib/Net/Braintree/Subscription.pm
+++ b/lib/Net/Braintree/Subscription.pm
@@ -53,4 +53,5 @@ sub gateway {
   return Net::Braintree->configuration->gateway;
 }
 
+__PACKAGE__->meta->make_immutable;
 1;

--- a/lib/Net/Braintree/Subscription.pm
+++ b/lib/Net/Braintree/Subscription.pm
@@ -2,7 +2,7 @@ package Net::Braintree::Subscription;
 use Net::Braintree::SubscriptionGateway;
 use Net::Braintree::Subscription::Status;
 
-use Moose;
+use Moo;
 extends 'Net::Braintree::ResultObject';
 
 

--- a/lib/Net/Braintree/SubscriptionGateway.pm
+++ b/lib/Net/Braintree/SubscriptionGateway.pm
@@ -2,7 +2,7 @@ package Net::Braintree::SubscriptionGateway;
 use Net::Braintree::Util qw(to_instance_array validate_id);
 use Carp qw(confess);
 
-use Moose;
+use Moo;
 
 has 'gateway' => (is => 'ro');
 

--- a/lib/Net/Braintree/SubscriptionGateway.pm
+++ b/lib/Net/Braintree/SubscriptionGateway.pm
@@ -61,5 +61,4 @@ sub fetch_subscriptions {
   my $attrs = $response->{'subscriptions'}->{'subscription'};
   return to_instance_array($attrs, "Net::Braintree::Subscription");
 }
-__PACKAGE__->meta->make_immutable;
 1;

--- a/lib/Net/Braintree/SubscriptionGateway.pm
+++ b/lib/Net/Braintree/SubscriptionGateway.pm
@@ -1,5 +1,6 @@
 package Net::Braintree::SubscriptionGateway;
 use Net::Braintree::Util qw(to_instance_array validate_id);
+use Carp qw(confess);
 
 use Moose;
 

--- a/lib/Net/Braintree/SubscriptionGateway.pm
+++ b/lib/Net/Braintree/SubscriptionGateway.pm
@@ -60,4 +60,5 @@ sub fetch_subscriptions {
   my $attrs = $response->{'subscriptions'}->{'subscription'};
   return to_instance_array($attrs, "Net::Braintree::Subscription");
 }
+__PACKAGE__->meta->make_immutable;
 1;

--- a/lib/Net/Braintree/SubscriptionSearch.pm
+++ b/lib/Net/Braintree/SubscriptionSearch.pm
@@ -23,4 +23,5 @@ sub to_hash {
   Net::Braintree::AdvancedSearch->search_to_hash(shift);
 }
 
+__PACKAGE__->meta->make_immutable;
 1;

--- a/lib/Net/Braintree/SubscriptionSearch.pm
+++ b/lib/Net/Braintree/SubscriptionSearch.pm
@@ -1,9 +1,8 @@
 package Net::Braintree::SubscriptionSearch;
 use Moose;
 use Net::Braintree::AdvancedSearch qw(search_to_hash);
-my $meta = __PACKAGE__->meta();
 
-my $field = Net::Braintree::AdvancedSearchFields->new(metaclass => $meta);
+my $field = Net::Braintree::AdvancedSearchFields->new(metaclass => __PACKAGE__->meta);
 
 $field->text("id");
 $field->text("transaction_id");

--- a/lib/Net/Braintree/SubscriptionSearch.pm
+++ b/lib/Net/Braintree/SubscriptionSearch.pm
@@ -22,5 +22,4 @@ sub to_hash {
   Net::Braintree::AdvancedSearch->search_to_hash(shift);
 }
 
-__PACKAGE__->meta->make_immutable;
 1;

--- a/lib/Net/Braintree/SubscriptionSearch.pm
+++ b/lib/Net/Braintree/SubscriptionSearch.pm
@@ -1,5 +1,5 @@
 package Net::Braintree::SubscriptionSearch;
-use Moose;
+use Moo;
 use Net::Braintree::AdvancedSearch qw(search_to_hash);
 
 my $field = Net::Braintree::AdvancedSearchFields->new(metaclass => __PACKAGE__->meta);

--- a/lib/Net/Braintree/TransactionGateway.pm
+++ b/lib/Net/Braintree/TransactionGateway.pm
@@ -100,5 +100,4 @@ sub fetch_transactions {
   return to_instance_array($attrs, "Net::Braintree::Transaction");
 }
 
-__PACKAGE__->meta->make_immutable;
 1;

--- a/lib/Net/Braintree/TransactionGateway.pm
+++ b/lib/Net/Braintree/TransactionGateway.pm
@@ -100,4 +100,5 @@ sub fetch_transactions {
   return to_instance_array($attrs, "Net::Braintree::Transaction");
 }
 
+__PACKAGE__->meta->make_immutable;
 1;

--- a/lib/Net/Braintree/TransactionGateway.pm
+++ b/lib/Net/Braintree/TransactionGateway.pm
@@ -1,5 +1,5 @@
 package Net::Braintree::TransactionGateway;
-use Moose;
+use Moo;
 use Carp qw(confess);
 use Net::Braintree::Util qw(validate_id);
 use Net::Braintree::Validations qw(verify_params transaction_signature clone_transaction_signature transaction_search_results_signature);

--- a/lib/Net/Braintree/TransactionSearch.pm
+++ b/lib/Net/Braintree/TransactionSearch.pm
@@ -1,5 +1,5 @@
 package Net::Braintree::TransactionSearch;
-use Moose;
+use Moo;
 use Net::Braintree::AdvancedSearch qw(search_to_hash);
 
 my $field = Net::Braintree::AdvancedSearchFields->new(metaclass => __PACKAGE__->meta);

--- a/lib/Net/Braintree/TransactionSearch.pm
+++ b/lib/Net/Braintree/TransactionSearch.pm
@@ -74,4 +74,5 @@ sub to_hash {
   Net::Braintree::AdvancedSearch->search_to_hash(shift);
 }
 
+__PACKAGE__->meta->make_immutable;
 1;

--- a/lib/Net/Braintree/TransactionSearch.pm
+++ b/lib/Net/Braintree/TransactionSearch.pm
@@ -1,9 +1,8 @@
 package Net::Braintree::TransactionSearch;
 use Moose;
 use Net::Braintree::AdvancedSearch qw(search_to_hash);
-my $meta = __PACKAGE__->meta();
 
-my $field = Net::Braintree::AdvancedSearchFields->new(metaclass => $meta);
+my $field = Net::Braintree::AdvancedSearchFields->new(metaclass => __PACKAGE__->meta);
 
 $field->text("billing_company");
 $field->text("billing_country_name");

--- a/lib/Net/Braintree/TransactionSearch.pm
+++ b/lib/Net/Braintree/TransactionSearch.pm
@@ -73,5 +73,4 @@ sub to_hash {
   Net::Braintree::AdvancedSearch->search_to_hash(shift);
 }
 
-__PACKAGE__->meta->make_immutable;
 1;

--- a/lib/Net/Braintree/TransparentRedirect.pm
+++ b/lib/Net/Braintree/TransparentRedirect.pm
@@ -40,4 +40,5 @@ sub gateway {
   Net::Braintree->configuration->gateway;
 }
 
+__PACKAGE__->meta->make_immutable;
 1;

--- a/lib/Net/Braintree/TransparentRedirect.pm
+++ b/lib/Net/Braintree/TransparentRedirect.pm
@@ -1,5 +1,5 @@
 package Net::Braintree::TransparentRedirect;
-use Moose;
+use Moo;
 
 sub confirm {
   my($class, $query_string) = @_;

--- a/lib/Net/Braintree/TransparentRedirect.pm
+++ b/lib/Net/Braintree/TransparentRedirect.pm
@@ -40,5 +40,4 @@ sub gateway {
   Net::Braintree->configuration->gateway;
 }
 
-__PACKAGE__->meta->make_immutable;
 1;

--- a/lib/Net/Braintree/TransparentRedirect/QueryString.pm
+++ b/lib/Net/Braintree/TransparentRedirect/QueryString.pm
@@ -40,4 +40,5 @@ sub check_http_status {
   confess "UnexpectedError"     if $params->{'http_status'} ne '200';
 }
 
+__PACKAGE__->meta->make_immutable;
 1;

--- a/lib/Net/Braintree/TransparentRedirect/QueryString.pm
+++ b/lib/Net/Braintree/TransparentRedirect/QueryString.pm
@@ -41,5 +41,4 @@ sub check_http_status {
   confess "UnexpectedError"     if $params->{'http_status'} ne '200';
 }
 
-__PACKAGE__->meta->make_immutable;
 1;

--- a/lib/Net/Braintree/TransparentRedirect/QueryString.pm
+++ b/lib/Net/Braintree/TransparentRedirect/QueryString.pm
@@ -1,7 +1,7 @@
 package Net::Braintree::TransparentRedirect::QueryString;
 use URI;
 use Net::Braintree::Digest qw(hexdigest);
-use Moose;
+use Moo;
 use Carp qw(confess);
 
 has 'config' => ( is => 'rw', default => sub { Net::Braintree->configuration});

--- a/lib/Net/Braintree/TransparentRedirect/QueryString.pm
+++ b/lib/Net/Braintree/TransparentRedirect/QueryString.pm
@@ -1,5 +1,5 @@
 package Net::Braintree::TransparentRedirect::QueryString;
-use CGI;
+use URI;
 use Net::Braintree::Digest qw(hexdigest);
 use Moose;
 use Carp qw(confess);
@@ -14,9 +14,10 @@ sub validate {
 }
 
 sub parse {
-  my ($self, $query_string) = @_;
-  my $query = CGI->new($query_string);
-  return $query->Vars;
+    my ($self, $query_string) = @_;
+    my $uri = URI->new;
+    $uri->query($query_string);
+    return { $uri->query_form};
 }
 
 sub hash_is_forged {

--- a/lib/Net/Braintree/TransparentRedirectGateway.pm
+++ b/lib/Net/Braintree/TransparentRedirectGateway.pm
@@ -1,5 +1,5 @@
 package Net::Braintree::TransparentRedirectGateway;
-use Moose;
+use Moo;
 
 use Carp qw(confess);
 use DateTime;

--- a/lib/Net/Braintree/TransparentRedirectGateway.pm
+++ b/lib/Net/Braintree/TransparentRedirectGateway.pm
@@ -103,4 +103,5 @@ sub _make_request {
   return $result;
 }
 
+__PACKAGE__->meta->make_immutable;
 1;

--- a/lib/Net/Braintree/TransparentRedirectGateway.pm
+++ b/lib/Net/Braintree/TransparentRedirectGateway.pm
@@ -103,5 +103,4 @@ sub _make_request {
   return $result;
 }
 
-__PACKAGE__->meta->make_immutable;
 1;

--- a/lib/Net/Braintree/UnknownPaymentMethod.pm
+++ b/lib/Net/Braintree/UnknownPaymentMethod.pm
@@ -9,4 +9,5 @@ sub BUILD {
   $self->set_attributes_from_hash($self, $attributes);
 }
 
+__PACKAGE__->meta->make_immutable;
 1;

--- a/lib/Net/Braintree/UnknownPaymentMethod.pm
+++ b/lib/Net/Braintree/UnknownPaymentMethod.pm
@@ -2,8 +2,6 @@ package Net::Braintree::UnknownPaymentMethod;
 use Moose;
 extends 'Net::Braintree::PaymentMethod';
 
-my $meta = __PACKAGE__->meta;
-
 sub BUILD {
   my ($self, $attributes) = @_;
   $self->set_attributes_from_hash($self, $attributes);

--- a/lib/Net/Braintree/UnknownPaymentMethod.pm
+++ b/lib/Net/Braintree/UnknownPaymentMethod.pm
@@ -7,5 +7,4 @@ sub BUILD {
   $self->set_attributes_from_hash($self, $attributes);
 }
 
-__PACKAGE__->meta->make_immutable;
 1;

--- a/lib/Net/Braintree/UnknownPaymentMethod.pm
+++ b/lib/Net/Braintree/UnknownPaymentMethod.pm
@@ -1,5 +1,5 @@
 package Net::Braintree::UnknownPaymentMethod;
-use Moose;
+use Moo;
 extends 'Net::Braintree::PaymentMethod';
 
 sub BUILD {

--- a/lib/Net/Braintree/ValidationError.pm
+++ b/lib/Net/Braintree/ValidationError.pm
@@ -5,5 +5,4 @@ has 'attribute' => (is => 'ro');
 has 'code' => (is => 'ro');
 has 'message' => (is => 'ro');
 
-__PACKAGE__->meta->make_immutable;
 1;

--- a/lib/Net/Braintree/ValidationError.pm
+++ b/lib/Net/Braintree/ValidationError.pm
@@ -5,4 +5,5 @@ has 'attribute' => (is => 'ro');
 has 'code' => (is => 'ro');
 has 'message' => (is => 'ro');
 
+__PACKAGE__->meta->make_immutable;
 1;

--- a/lib/Net/Braintree/ValidationError.pm
+++ b/lib/Net/Braintree/ValidationError.pm
@@ -1,5 +1,5 @@
 package Net::Braintree::ValidationError;
-use Moose;
+use Moo;
 
 has 'attribute' => (is => 'ro');
 has 'code' => (is => 'ro');

--- a/lib/Net/Braintree/ValidationErrorCollection.pm
+++ b/lib/Net/Braintree/ValidationErrorCollection.pm
@@ -34,4 +34,5 @@ sub on {
   return [ grep { $_->attribute eq $attribute } @{$self->{_errors}} ]
 }
 
+__PACKAGE__->meta->make_immutable;
 1;

--- a/lib/Net/Braintree/ValidationErrorCollection.pm
+++ b/lib/Net/Braintree/ValidationErrorCollection.pm
@@ -1,6 +1,6 @@
 package Net::Braintree::ValidationErrorCollection;
 
-use Moose;
+use Moo;
 use Net::Braintree::Util;
 use Net::Braintree::ValidationError;
 

--- a/lib/Net/Braintree/ValidationErrorCollection.pm
+++ b/lib/Net/Braintree/ValidationErrorCollection.pm
@@ -34,5 +34,4 @@ sub on {
   return [ grep { $_->attribute eq $attribute } @{$self->{_errors}} ]
 }
 
-__PACKAGE__->meta->make_immutable;
 1;

--- a/lib/Net/Braintree/WebhookNotification.pm
+++ b/lib/Net/Braintree/WebhookNotification.pm
@@ -5,10 +5,9 @@ use Moose;
 
 extends 'Net::Braintree::ResultObject';
 
-my $meta = __PACKAGE__->meta;
-
 sub BUILD {
   my ($self, $attributes) = @_;
+  my $meta = __PACKAGE__->meta;
 
   my $wrapper_node = $attributes->{subject};
 

--- a/lib/Net/Braintree/WebhookNotificationGateway.pm
+++ b/lib/Net/Braintree/WebhookNotificationGateway.pm
@@ -4,6 +4,7 @@ use MIME::Base64;
 use Net::Braintree::Digest qw(hexdigest);
 use Net::Braintree::Xml qw(xml_to_hash);
 use Moose;
+use Carp qw(confess);
 
 has 'gateway' => (is => 'ro');
 

--- a/lib/Net/Braintree/WebhookNotificationGateway.pm
+++ b/lib/Net/Braintree/WebhookNotificationGateway.pm
@@ -3,8 +3,8 @@ package Net::Braintree::WebhookNotificationGateway;
 use MIME::Base64;
 use Net::Braintree::Digest qw(hexdigest);
 use Net::Braintree::Xml qw(xml_to_hash);
-use Moose;
 use Carp qw(confess);
+use Moo;
 
 has 'gateway' => (is => 'ro');
 

--- a/lib/Net/Braintree/WebhookNotificationGateway.pm
+++ b/lib/Net/Braintree/WebhookNotificationGateway.pm
@@ -43,4 +43,5 @@ sub verify {
   return $self->gateway->config->public_key . "|" . hexdigest($self->gateway->config->private_key, $challenge);
 }
 
+__PACKAGE__->meta->make_immutable;
 1;

--- a/lib/Net/Braintree/WebhookNotificationGateway.pm
+++ b/lib/Net/Braintree/WebhookNotificationGateway.pm
@@ -44,5 +44,4 @@ sub verify {
   return $self->gateway->config->public_key . "|" . hexdigest($self->gateway->config->private_key, $challenge);
 }
 
-__PACKAGE__->meta->make_immutable;
 1;

--- a/lib/Net/Braintree/WebhookTesting.pm
+++ b/lib/Net/Braintree/WebhookTesting.pm
@@ -13,5 +13,4 @@ sub gateway {
   return Net::Braintree->configuration->gateway;
 }
 
-__PACKAGE__->meta->make_immutable;
 1;

--- a/lib/Net/Braintree/WebhookTesting.pm
+++ b/lib/Net/Braintree/WebhookTesting.pm
@@ -2,7 +2,6 @@ package Net::Braintree::WebhookTesting;
 
 use Moose;
 
-my $meta = __PACKAGE__->meta;
 
 sub sample_notification {
   my ($class, $kind, $id) = @_;

--- a/lib/Net/Braintree/WebhookTesting.pm
+++ b/lib/Net/Braintree/WebhookTesting.pm
@@ -1,6 +1,6 @@
 package Net::Braintree::WebhookTesting;
 
-use Moose;
+use Moo;
 
 
 sub sample_notification {

--- a/lib/Net/Braintree/WebhookTesting.pm
+++ b/lib/Net/Braintree/WebhookTesting.pm
@@ -14,4 +14,5 @@ sub gateway {
   return Net::Braintree->configuration->gateway;
 }
 
+__PACKAGE__->meta->make_immutable;
 1;

--- a/lib/Net/Braintree/WebhookTestingGateway.pm
+++ b/lib/Net/Braintree/WebhookTestingGateway.pm
@@ -269,4 +269,5 @@ sub _partner_merchant_declined_sample_xml {
 XML
 }
 
+__PACKAGE__->meta->make_immutable;
 1;

--- a/lib/Net/Braintree/WebhookTestingGateway.pm
+++ b/lib/Net/Braintree/WebhookTestingGateway.pm
@@ -269,5 +269,4 @@ sub _partner_merchant_declined_sample_xml {
 XML
 }
 
-__PACKAGE__->meta->make_immutable;
 1;

--- a/lib/Net/Braintree/WebhookTestingGateway.pm
+++ b/lib/Net/Braintree/WebhookTestingGateway.pm
@@ -4,7 +4,7 @@ use MIME::Base64;
 use POSIX qw(strftime);
 use Net::Braintree::Digest qw(hexdigest);
 use Net::Braintree::WebhookNotification::Kind;
-use Moose;
+use Moo;
 
 has 'gateway' => (is => 'ro');
 

--- a/t/advanced_search.t
+++ b/t/advanced_search.t
@@ -6,9 +6,8 @@ use Net::Braintree::TestHelper;
 package Net::Braintree::AdvancedSearchTest;
 use Moose;
 use Net::Braintree::AdvancedSearch qw(search_to_hash);
-my $meta = __PACKAGE__->meta();
 
-my $field = Net::Braintree::AdvancedSearchFields->new(metaclass => $meta);
+my $field = Net::Braintree::AdvancedSearchFields->new(metaclass => __PACKAGE__->meta);
 $field->text("billing_company");
 $field->equality("credit_card_expiration_date");
 $field->range("amount");

--- a/t/advanced_search.t
+++ b/t/advanced_search.t
@@ -19,6 +19,7 @@ $field->key_value("refund");
 
 
 
+__PACKAGE__->meta->make_immutable;
 1;
 }
 

--- a/t/lib/Net/Braintree/ClientApiHTTP.pm
+++ b/t/lib/Net/Braintree/ClientApiHTTP.pm
@@ -137,4 +137,5 @@ sub _do_http {
   return $agent->request($request);
 };
 
+__PACKAGE__->meta->make_immutable;
 1;

--- a/t/lib/Net/Braintree/MockHTTP.pm
+++ b/t/lib/Net/Braintree/MockHTTP.pm
@@ -39,4 +39,5 @@ sub delete {
   return $self -> result;
 }
 
+__PACKAGE__->meta->make_immutable;
 1;

--- a/t/lib/Net/Braintree/TestHelper.pm
+++ b/t/lib/Net/Braintree/TestHelper.pm
@@ -9,7 +9,7 @@ use LWP::UserAgent;
 use MIME::Base64;
 use Net::Braintree::Util;
 use DateTime::Format::Strptime;
-use CGI;
+use URI::Escape;
 use JSON;
 
 use Net::Braintree;
@@ -118,7 +118,7 @@ sub create_3ds_verification {
 
 sub simulate_form_post_for_tr {
   my ($tr_string, $form_params) = @_;
-  my $escaped_tr_string = CGI::escape($tr_string);
+  my $escaped_tr_string = uri_escape($tr_string);
   my $tr_data = {tr_data => $escaped_tr_string, %$form_params};
 
   my $request = HTTP::Request->new(POST => Net::Braintree->configuration->base_merchant_url .


### PR DESCRIPTION
There are a number of problems with the code style in this set of packages.

I've used the test suite to make safe refactorings to address these issues, although I am unable to run integration tests.

The usage of moose is problematic (using the metaobject protocol to add attributes at runtime) as it makes the code difficult to understand, especially without documentation, so I have not touched this stuff.  It also creates substantial overhead, which is bad for code designed to be integrated into other applications.

I am going to kick up a discussion in the perl community, and hopefully with paypal to see if there is anything we can do to get rid of or modify the deprecation notice.  It seems like a strange decision for a language in the top 10 Tiobe index, and for a language that still runs a substantial quantity of high value ecommerce operations.  I'm sure I can work with people in the perl community on  architecture of this codebase to improve its maintainability, which may be the real problem causing the module's deprecation.