### PR TITLE
Allow sending 0 values via web service

### DIFF
--- a/lib/Net/Braintree/Xml.pm
+++ b/lib/Net/Braintree/Xml.pm
@@ -31,7 +31,7 @@ sub add_node {
   } elsif(is_arrayref($value)){
     build_from_array($parent, $value);
   } else {
-    $parent->appendText($value) if $value;
+    $parent->appendText($value) if defined($value) and length($value);
   }
 }
 


### PR DESCRIPTION
Before the code was mistakenly excluding not just undef and empty string
values, but also bare number 0.